### PR TITLE
Fix: Firebase AppCheck failure

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -59,8 +59,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/firebase/firebase-ios-sdk",
       "state" : {
-        "revision" : "8bcaf973b1d84e119b7c7c119abad72ed460979f",
-        "version" : "10.27.0"
+        "revision" : "9d17b500cd98d9a7009751ad62f802e152e97021",
+        "version" : "10.26.0"
       }
     },
     {
@@ -68,8 +68,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/google/GoogleAppMeasurement.git",
       "state" : {
-        "revision" : "70df02431e216bed98dd461e0c4665889245ba70",
-        "version" : "10.27.0"
+        "revision" : "16244d177c4e989f87b25e9db1012b382cfedc55",
+        "version" : "10.25.0"
       }
     },
     {
@@ -154,15 +154,6 @@
       }
     },
     {
-      "identity" : "runtime",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/urlaunched-com/Runtime",
-      "state" : {
-        "revision" : "ea112a73f7a8772a92b125ceeaaf61f1844466bd",
-        "version" : "2.2.6"
-      }
-    },
-    {
       "identity" : "swift-collections",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-collections",
@@ -185,8 +176,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/Maks-Jago/SwiftUI-UDF",
       "state" : {
-        "revision" : "7f19453c042cb3dd572299ceaa6e075c4b6ca69e",
-        "version" : "1.4.5-rc.2"
+        "revision" : "65c4b16b0545f27bd3a5b9edae2a59b0538d0e68",
+        "version" : "1.4.3-rc.2"
       }
     }
   ],

--- a/Package.resolved
+++ b/Package.resolved
@@ -59,8 +59,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/firebase/firebase-ios-sdk",
       "state" : {
-        "revision" : "9d17b500cd98d9a7009751ad62f802e152e97021",
-        "version" : "10.26.0"
+        "revision" : "8bcaf973b1d84e119b7c7c119abad72ed460979f",
+        "version" : "10.27.0"
       }
     },
     {
@@ -68,8 +68,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/google/GoogleAppMeasurement.git",
       "state" : {
-        "revision" : "16244d177c4e989f87b25e9db1012b382cfedc55",
-        "version" : "10.25.0"
+        "revision" : "70df02431e216bed98dd461e0c4665889245ba70",
+        "version" : "10.27.0"
       }
     },
     {
@@ -154,6 +154,15 @@
       }
     },
     {
+      "identity" : "runtime",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/urlaunched-com/Runtime",
+      "state" : {
+        "revision" : "ea112a73f7a8772a92b125ceeaaf61f1844466bd",
+        "version" : "2.2.6"
+      }
+    },
+    {
       "identity" : "swift-collections",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-collections",
@@ -176,8 +185,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/Maks-Jago/SwiftUI-UDF",
       "state" : {
-        "revision" : "65c4b16b0545f27bd3a5b9edae2a59b0538d0e68",
-        "version" : "1.4.3-rc.2"
+        "revision" : "7f19453c042cb3dd572299ceaa6e075c4b6ca69e",
+        "version" : "1.4.5-rc.2"
       }
     }
   ],

--- a/Sources/UDFAnalyticsFirebase/AnalyticsFirebase.swift
+++ b/Sources/UDFAnalyticsFirebase/AnalyticsFirebase.swift
@@ -11,13 +11,7 @@ private typealias FAnalytics = FirebaseAnalytics.Analytics
 
 public struct AnalyticsFirebase<Event: RawRepresentable>: UDFAnalytics.Analytics where Event.RawValue == String {
 
-    public init() {
-        if !ProcessInfo.processInfo.xcTest {
-            let filePath = Bundle.main.path(forResource: "GoogleService-Info", ofType: "plist")!
-            let options = FirebaseOptions(contentsOfFile: filePath)
-            FirebaseApp.configure(options: options!)
-        }
-    }
+    public init() {}
 
     public func logEvent(_ event: Event) {
         FAnalytics.logEvent(event.rawValue, parameters: nil)
@@ -90,6 +84,17 @@ public struct AnalyticsFirebase<Event: RawRepresentable>: UDFAnalytics.Analytics
         application: UIApplication,
         _ launchOptions: [UIApplication.LaunchOptionsKey : Any]?
     ) {
-        //do nothing
+        guard !ProcessInfo.processInfo.xcTest else { return }
+        
+        DispatchQueue.main.async {
+            if FirebaseApp.app() == nil {
+                if let filePath = Bundle.main.path(forResource: "GoogleService-Info", ofType: "plist"),
+                   let options = FirebaseOptions(contentsOfFile: filePath) {
+                    FirebaseApp.configure(options: options)
+                } else {
+                    FirebaseApp.configure()
+                }
+            }
+        }
     }
 }

--- a/Sources/UDFAnalyticsFirebase/AnalyticsFirebase.swift
+++ b/Sources/UDFAnalyticsFirebase/AnalyticsFirebase.swift
@@ -80,19 +80,20 @@ public struct AnalyticsFirebase<Event: RawRepresentable>: UDFAnalytics.Analytics
         //do nothing
     }
 
-    @MainActor
     public func applicationDidLaunchWithOptions(
         application: UIApplication,
         _ launchOptions: [UIApplication.LaunchOptionsKey : Any]?
     ) {
         guard !ProcessInfo.processInfo.xcTest else { return }
         
-        if FirebaseApp.app() == nil {
-            if let filePath = Bundle.main.path(forResource: "GoogleService-Info", ofType: "plist"),
-               let options = FirebaseOptions(contentsOfFile: filePath) {
-                FirebaseApp.configure(options: options)
-            } else {
-                FirebaseApp.configure()
+        DispatchQueue.main.async {
+            if FirebaseApp.app() == nil {
+                if let filePath = Bundle.main.path(forResource: "GoogleService-Info", ofType: "plist"),
+                   let options = FirebaseOptions(contentsOfFile: filePath) {
+                    FirebaseApp.configure(options: options)
+                } else {
+                    FirebaseApp.configure()
+                }
             }
         }
     }

--- a/Sources/UDFAnalyticsFirebase/AnalyticsFirebase.swift
+++ b/Sources/UDFAnalyticsFirebase/AnalyticsFirebase.swift
@@ -80,20 +80,19 @@ public struct AnalyticsFirebase<Event: RawRepresentable>: UDFAnalytics.Analytics
         //do nothing
     }
 
+    @MainActor
     public func applicationDidLaunchWithOptions(
         application: UIApplication,
         _ launchOptions: [UIApplication.LaunchOptionsKey : Any]?
     ) {
         guard !ProcessInfo.processInfo.xcTest else { return }
         
-        DispatchQueue.main.async {
-            if FirebaseApp.app() == nil {
-                if let filePath = Bundle.main.path(forResource: "GoogleService-Info", ofType: "plist"),
-                   let options = FirebaseOptions(contentsOfFile: filePath) {
-                    FirebaseApp.configure(options: options)
-                } else {
-                    FirebaseApp.configure()
-                }
+        if FirebaseApp.app() == nil {
+            if let filePath = Bundle.main.path(forResource: "GoogleService-Info", ofType: "plist"),
+               let options = FirebaseOptions(contentsOfFile: filePath) {
+                FirebaseApp.configure(options: options)
+            } else {
+                FirebaseApp.configure()
             }
         }
     }


### PR DESCRIPTION
If FirebaseApp was not already initialized by developer themselves beforehand in AppDelegate before dispatching actions ApplicationDidLaunchWithOptions, then initialize FirebaseApp as previously.